### PR TITLE
Fix reading font size from user config on linux

### DIFF
--- a/config/conf.toml
+++ b/config/conf.toml
@@ -2,3 +2,11 @@
 tsdb.backend = 'marketstore'
 tsdb.host = 'localhost'
 tsdb.grpc_port = 5995
+
+[ui]
+# set custom font + size which will scale entire UI
+# font_size = 16
+# font_name = 'Monospaced'
+
+# colorscheme = 'default'  # UNUSED
+# graphics.update_throttle = 60  # Hz  # TODO

--- a/piker/ui/_axes.py
+++ b/piker/ui/_axes.py
@@ -418,7 +418,7 @@ class AxisLabel(pg.GraphicsObject):
 
         self._txt_br: QtCore.QRect = None
 
-        self._dpifont = DpiAwareFont(font_size=font_size)
+        self._dpifont = DpiAwareFont(_font_size_key=font_size)
         self._dpifont.configure_to_dpi()
 
         self.bg_color = pg.mkColor(hcolor(bg_color))

--- a/piker/ui/_label.py
+++ b/piker/ui/_label.py
@@ -84,7 +84,7 @@ class Label:
 
         # configure font size based on DPI
         dpi_font = DpiAwareFont(
-            font_size=font_size,
+            _font_size_key=font_size,
         )
         dpi_font.configure_to_dpi()
         txt.setFont(dpi_font.font)

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -52,28 +52,26 @@ class DpiAwareFont:
     def __init__(
         self,
         name: str = 'Hack',
-        font_size: str = 'default',
+        _font_size_key: str = 'default',
 
     ) -> None:
-        self._custom_ui = False
+
+        self._font_size_calc_key: str = _font_size_key
+        self._font_size: int | None = None
+
         # Read preferred font size from main config file if it exists
         conf, path = config.load('conf', touch_if_dne=True)
-        ui_section = conf.get('ui')
-        if ui_section:
-            self._custom_ui = True
+        if ui_section := conf.get('ui'):
+            if font_size := ui_section.get('font_size'):
+                self._font_size = int(font_size)
 
-            font_size = ui_section.get('font_size')
-            if not font_size:
-                font_size = 'default'
-
-            name = ui_section.get('name')
-            if not name:
-                name = 'Hack'
+            if not (name := ui_section.get('font_name')):
+                name: str = 'Hack'
 
         self.name = name
         self._qfont = QtGui.QFont(name)
-        self._font_size: str = font_size
         self._qfm = QtGui.QFontMetrics(self._qfont)
+
         self._font_inches: float = None
         self._screen = None
 
@@ -115,9 +113,13 @@ class DpiAwareFont:
         listed in the script in ``snippets/qt_screen_info.py``.
 
         '''
-        if self._custom_ui:
+        if self._font_size is not None:
             self._set_qfont_px_size(self._font_size)
             return
+
+        # NOTE: if no font size set either in the [ui] section of the
+        # config or not yet computed from our magic scaling calcs,
+        # then attempt to caculate it here!
 
         if screen is None:
             screen = self.screen
@@ -136,10 +138,10 @@ class DpiAwareFont:
         scale = round(ldpi/pdpi, ndigits=2)
 
         if mx_dpi <= 97:  # for low dpi use larger font sizes
-            inches = _font_sizes['lo'][self._font_size]
+            inches = _font_sizes['lo'][self._font_size_calc_key]
 
         else:  # hidpi use smaller font sizes
-            inches = _font_sizes['hi'][self._font_size]
+            inches = _font_sizes['hi'][self._font_size_calc_key]
 
         dpi = mn_dpi
 
@@ -148,7 +150,7 @@ class DpiAwareFont:
         # No implicit DPI scaling was done by the DE so let's engage
         # some hackery ad-hoc scaling shiat.
         # dpi is likely somewhat scaled down so use slightly larger font size
-        if scale >= 1.1 and self._font_size:
+        if scale >= 1.1 and self._font_size_calc_key:
 
             # no idea why
             if 1.2 <= scale:
@@ -204,7 +206,7 @@ class DpiAwareFont:
 
 # use inches size to be cross-resolution compatible?
 _font = DpiAwareFont()
-_font_small = DpiAwareFont(font_size='small')
+_font_small = DpiAwareFont(_font_size_key='small')
 
 
 def _config_fonts_to_screen() -> None:


### PR DESCRIPTION
Was borked on linux if you didn't provide the setting in `conf.toml` due to some logic errors. Fix that by rejigging `DpiAwareFont` internal variables and changing client code throughout `piker.ui` subpkg.

This is to add to and fix https://github.com/pikers/piker/pull/523 so it works on linux **and** when no config section has:

```toml
[ui]
font_size = 16
font_name = 'MyFontz'
```

Oh, and also adds the commented fields to our template config B)